### PR TITLE
Fix Travis builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,11 @@ before_install:
 install: mvn -U install -Ddocker.skip=true -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 
 script: if [ "$TRAVIS_PULL_REQUEST" == "false" ] ; then mvn -s ./settings.xml deploy
-  -DtrimStackTrace=false; else mvn verify -DtrimStackTrace=false; fi
+  -DtrimStackTrace=false; else mvn verify -DtrimStackTrace=false -Ddocker.keepRunning -Ddocker.useColor=false ; fi
 
 jdk:
   - oraclejdk8
+
+after_failure:
+  - docker logs `docker ps |grep index|awk '{print $1}'`
+  - docker logs `docker ps|grep provider-integration-its|awk '{print $1}'`

--- a/jscholarship-package-provider/pom.xml
+++ b/jscholarship-package-provider/pom.xml
@@ -39,7 +39,7 @@
                 <executions>
                     <execution>
                         <id>build-after-its</id>
-                        <phase>install</phase>
+                        <phase>verify</phase>
                         <goals>
                             <goal>build</goal>
                         </goals>

--- a/nihms-package-provider/pom.xml
+++ b/nihms-package-provider/pom.xml
@@ -39,7 +39,7 @@
                 <executions>
                     <execution>
                         <id>build-after-its</id>
-                        <phase>install</phase>
+                        <phase>verify</phase>
                         <goals>
                             <goal>build</goal>
                         </goals>

--- a/provider-integration/pom.xml
+++ b/provider-integration/pom.xml
@@ -153,20 +153,6 @@
                                     </run>
                                 </image>
 
-                                <!-- Assets -->
-
-                                <image>
-                                    <name>${docker.assets.version}</name>
-                                    <alias>assets</alias>
-                                    <run>
-                                        <volumes>
-                                            <bind>
-                                                <volume>/data</volume>
-                                            </bind>
-                                        </volumes>
-                                    </run>
-                                </image>
-
                                 <!-- Fedora, Elastic Search, and the Indexer -->
 
                                 <image>
@@ -188,7 +174,7 @@
                                             <port>${fcrepo.stomp.port}:${fcrepo.stomp.port}</port>
                                         </ports>
                                         <env>
-                                            <FCREPO_HOME>/data</FCREPO_HOME>
+                                            <FCREPO_HOME>/usr/local/tomcat/fcrepo4-data</FCREPO_HOME>
                                             <FCREPO_HOST>fcrepo</FCREPO_HOST>
                                             <FCREPO_PORT>${fcrepo.http.port}</FCREPO_PORT>
                                             <FCREPO_JMS_PORT>${fcrepo.jms.port}</FCREPO_JMS_PORT>
@@ -200,11 +186,6 @@
                                             <name>its</name>
                                             <alias>fcrepo</alias>
                                         </network>
-                                        <volumes>
-                                            <from>
-                                                <image>assets</image>
-                                            </from>
-                                        </volumes>
                                     </run>
                                 </image>
                                 <image>
@@ -224,18 +205,12 @@
                                         <env>
                                             <discovery.type>single-node</discovery.type>
                                             <bootstrap.memory_lock>true</bootstrap.memory_lock>
-                                            <path.data>/data</path.data>
                                             <ES_JAVA_OPTS>-Xms512m -Xmx512m</ES_JAVA_OPTS>
                                         </env>
                                         <network>
                                             <name>its</name>
                                             <alias>elasticsearch</alias>
                                         </network>
-                                        <volumes>
-                                            <from>
-                                                <image>assets</image>
-                                            </from>
-                                        </volumes>
                                     </run>
                                 </image>
                                 <image>
@@ -253,11 +228,17 @@
                                             <PI_FEDORA_JMS_QUEUE>fedora</PI_FEDORA_JMS_QUEUE>
                                             <PI_TYPE_PREFIX>http://oapass.org/ns/pass#</PI_TYPE_PREFIX>
                                             <PI_LOG_LEVEL>DEBUG</PI_LOG_LEVEL>
+                                            <PI_ES_CONFIG>/app/esconfig/esconfig-3.4.json</PI_ES_CONFIG>
                                         </env>
                                         <network>
                                             <name>its</name>
                                             <alias>indexer</alias>
                                         </network>
+                                        <volumes>
+                                            <bind>
+                                                <volume>${project.build.testOutputDirectory}/esconfig:/app/esconfig</volume>
+                                            </bind>
+                                        </volumes>
                                     </run>
                                 </image>
                             </images>

--- a/provider-integration/pom.xml
+++ b/provider-integration/pom.xml
@@ -144,6 +144,10 @@
                                                 <!-- packages written by deposit services will be visible under
                                                      'target/packages' -->
                                                 <volume>${project.build.directory}/packages:/packages</volume>
+
+                                                <!-- overwrite /etc/hosts with an empty file, so that the alias
+                                                     'localhost' resolves to the fcrepo container -->
+                                                <volume>${project.build.testOutputDirectory}/hosts:/etc/hosts</volume>
                                             </bind>
                                         </volumes>
                                         <env>
@@ -191,6 +195,7 @@
                                         <network>
                                             <name>its</name>
                                             <alias>fcrepo</alias>
+                                            <alias>localhost</alias>
                                         </network>
                                     </run>
                                 </image>

--- a/provider-integration/pom.xml
+++ b/provider-integration/pom.xml
@@ -124,11 +124,15 @@
                                     </run>
                                 </image>
                                 <image>
-                                    <!-- IT image derived from production image: build, and run for ITs -->
-                                    <!-- This container is not exposed to the IT runtime; ITs submit content to Fedora
-                                         and inspect the generated packages -->
+                                    <!-- IT image derived from production image above: used to build, and provides the
+                                         Deposit Services runtime for ITs -->
+                                    <!-- This container is not exposed to the IT runtime; ITs only communicate with
+                                         Fedora; they submit content to Fedora and inspect the generated packages
+                                         created by this image -->
                                     <name>providers/provider-integration-its</name>
                                     <build>
+                                        <!-- Adds our runtime configuration which uses the Filesystem Tranpsort, and
+                                             creates a directory for written packages -->
                                         <dockerFile>Dockerfile-ITs</dockerFile>
                                     </build>
                                     <run>
@@ -137,6 +141,8 @@
                                         </network>
                                         <volumes>
                                             <bind>
+                                                <!-- packages written by deposit services will be visible under
+                                                     'target/packages' -->
                                                 <volume>${project.build.directory}/packages:/packages</volume>
                                             </bind>
                                         </volumes>

--- a/provider-integration/src/test/resources/esconfig/esconfig-3.4.json
+++ b/provider-integration/src/test/resources/esconfig/esconfig-3.4.json
@@ -1,0 +1,129 @@
+{
+  "settings": {
+    "index" : {
+      "refresh_interval" : "1s"
+    },
+    "analysis": {
+      "char_filter" : {
+        "fedora_uri_to_path" : {
+          "type": "pattern_replace",
+          "pattern": "\\Ahttp.*?/fcrepo/rest",
+          "replacement": ""
+        },
+        "nih_zero_ignore" : {
+          "type": "pattern_replace",
+          "pattern": "\\A[A-Za-z]\\w\\d([A-Za-z][A-Za-z])0{0,4}(\\d{2,6})\\Z",
+          "replacement": "$1$2"
+        },
+        "period_dash_whitespace_ignore" : {
+          "type": "pattern_replace",
+          "pattern": "\\.|-|\\s",
+          "replacement": ""
+        }
+      },
+      "normalizer": {
+        "ignorecase": {
+          "type": "custom",
+          "char_filter": [],
+          "filter": ["lowercase", "asciifolding"]
+        },
+        "fedora_uri": {
+          "type": "custom",
+          "char_filter": ["fedora_uri_to_path"],
+          "filter": []
+        },
+        "award_number": {
+          "type": "custom",
+          "char_filter": ["period_dash_whitespace_ignore", "nih_zero_ignore"],
+          "filter": ["lowercase", "asciifolding"]
+        }
+      }
+    }
+  },
+  "mappings": {
+    "_doc": {
+      "dynamic": false,
+      "properties": {
+        "@context": {"type": "keyword", "normalizer": "fedora_uri"},
+        "@id": {"type": "keyword", "normalizer": "fedora_uri"},
+        "@type": {"type": "keyword"},
+        "abstract": {"type": "text"},
+        "accessUrl": {"type": "keyword"},
+        "affiliation": {"type": "text"},
+        "aggregatedDepositStatus": {"type": "keyword"},
+        "agreementText": {"type": "text"},
+        "awardDate": {"type": "date"},
+        "awardNumber": {"type": "keyword", "normalizer": "award_number"},
+        "awardStatus": {"type": "keyword"},
+        "comment": {"type": "text"},
+        "coPis": {"type": "keyword", "normalizer": "fedora_uri"},
+        "copyStatus": {"type": "keyword"},
+        "depositStatus": {"type": "keyword"},
+        "depositStatusRef": {"type": "keyword"},
+        "description": {"type": "text"},
+        "directFunder": {"type": "keyword", "normalizer": "fedora_uri"},
+        "displayName": {"type": "text", "analyzer": "simple"},
+        "doi": {"type": "keyword", "normalizer": "ignorecase"},
+        "email": {"type": "keyword", "normalizer": "ignorecase"},
+        "endDate": {"type": "date"},
+        "eventType": {"type": "keyword"},
+        "externalIds": {"type": "keyword", "normalizer": "fedora_uri"},
+        "fileRole": {"type": "keyword"},
+        "firstName": {"type": "text", "analyzer": "simple"},
+        "formSchema": {"type": "keyword"},
+        "grants": {"type": "keyword", "normalizer": "fedora_uri"},
+        "integrationType": {"type": "keyword"},
+        "institution": {"type": "keyword"},
+        "issue": {"type": "keyword"},
+        "issns": {"type": "keyword"},
+        "lastName": {"type": "text", "analyzer": "simple"},
+        "locatorIds": {"type": "keyword"},
+        "journal": {"type": "keyword", "normalizer": "fedora_uri"},
+        "journalName": {"type": "text"},
+        "journalName_suggest": {"type": "completion"},
+        "localKey": {"type": "keyword"},
+        "link": {"type": "keyword", "normalizer": "fedora_uri"},
+        "metadata": {"type": "text"},
+        "middleName": {"type": "text", "analyzer": "simple"},
+        "mimeType": {"type": "keyword"},
+        "name": {"type": "text"},
+        "nlmta": {"type": "keyword"},
+        "orcidId": {"type": "keyword"},
+        "performedDate": {"type": "date"},
+        "performedBy": {"type": "keyword", "normalizer": "fedora_uri"},
+        "performerRole": {"type": "keyword"},
+        "pi": {"type": "keyword", "normalizer": "fedora_uri"},
+        "pmcParticipation": {"type": "keyword"},
+        "pmid": {"type": "keyword"},
+        "policy": {"type": "keyword", "normalizer": "fedora_uri"},
+        "policyUrl": {"type": "keyword"},
+        "preparers": {"type": "keyword", "normalizer": "fedora_uri"},
+        "primaryFunder": {"type": "keyword", "normalizer": "fedora_uri"},
+        "projectName": {"type": "text"},
+        "publisher": {"type": "keyword", "normalizer": "fedora_uri"},
+        "publication": {"type": "keyword", "normalizer": "fedora_uri"},
+        "repository": {"type": "keyword", "normalizer": "fedora_uri"},
+        "repositoryKey": {"type": "keyword"},
+        "repositoryCopy": {"type": "keyword", "normalizer": "fedora_uri"},
+        "repositories": {"type": "keyword", "normalizer": "fedora_uri"},
+        "roles": {"type": "keyword"},
+        "schemas": {"type": "keyword"},
+        "source": {"type": "keyword"},
+        "startDate": {"type": "date"},
+        "submission": {"type": "keyword", "normalizer": "fedora_uri"},
+        "submissionStatus": {"type": "keyword"},
+        "submitted": {"type": "boolean"},
+        "submittedDate": {"type": "date"},
+        "submitter": {"type": "keyword", "normalizer": "fedora_uri"},
+        "submitterEmail": {"type": "keyword"},
+        "submitterName": {"type": "text", "analyzer": "simple"},
+        "title": {"type": "text"},
+        "uri": {"type": "keyword"},
+        "url": {"type": "keyword"},
+        "user": {"type": "keyword", "normalizer": "fedora_uri"},
+        "username": {"type": "keyword"},
+        "volume": {"type": "keyword"}
+      }
+    }
+  }
+}

--- a/provider-integration/src/test/resources/hosts
+++ b/provider-integration/src/test/resources/hosts
@@ -1,0 +1,1 @@
+# intentionally empty


### PR DESCRIPTION
Fixes the Travis build so ITs pass.
- no longer use the `assets` image, which would require `docker login` (secure env vars do not work across forks)
- build provider docker images in `verify` phase instead of `install`
- address `fcrepo` as `localhost`