### PR TITLE
Update use of shared-resources module

### DIFF
--- a/jscholarship-package-provider/pom.xml
+++ b/jscholarship-package-provider/pom.xml
@@ -125,17 +125,6 @@
             <artifactId>shared-resources</artifactId>
             <version>${deposit-services.version}</version>
             <scope>test</scope>
-            <classifier>tests</classifier>
-            <type>test-jar</type>
-        </dependency>
-
-        <dependency>
-            <groupId>org.dataconservancy.pass.deposit</groupId>
-            <artifactId>fedora-builder</artifactId>
-            <version>${deposit-services.version}</version>
-            <scope>test</scope>
-            <classifier>tests</classifier>
-            <type>test-jar</type>
         </dependency>
 
         <dependency>
@@ -160,12 +149,6 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>io.github.lukehutch</groupId>
-            <artifactId>fast-classpath-scanner</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/jscholarship-package-provider/src/test/java/edu/jhu/library/pass/deposit/provider/j10p/MetadataTest.java
+++ b/jscholarship-package-provider/src/test/java/edu/jhu/library/pass/deposit/provider/j10p/MetadataTest.java
@@ -90,15 +90,10 @@ public class MetadataTest {
         // Create XML DOM for DSpace metadata from deposit services data model
         Element qdc = domWriter.createDublinCoreMetadataDCMES(depositSubmission);
 
-        // Publisher name in "crossref" has precedence over one in "common".
-        assertNotNull(qdc.getElementsByTagNameNS(DC_NS, DC_PUBLISHER).item(0).getTextContent());
-        assertEquals("Springer", qdc.getElementsByTagNameNS(DC_NS, DC_PUBLISHER).item(0).getTextContent());
-
         // In citation, use "et al" for more than three authors.
         // Publication date in "crossref" has precedence over one in "common".
         assertNotNull(qdc.getElementsByTagNameNS(DCTERMS_NS, DCT_BIBLIOCITATION).item(0).getTextContent());
-        String foo = qdc.getElementsByTagNameNS(DCTERMS_NS, DCT_BIBLIOCITATION).item(0).getTextContent();
-        assertEquals("Christine Cagney, Mary Beth Lacey, David Michael Starsky, et al. (Spring 2018). \"My Test Article.\" Nature Communications.",
+        assertEquals("Christine Cagney, Mary Beth Lacey, David Michael Starsky, et al. (Fall 2016). \"My Test Article.\" Nature Communications.",
                 qdc.getElementsByTagNameNS(DCTERMS_NS, DCT_BIBLIOCITATION).item(0).getTextContent());
     }
 }

--- a/jscholarship-package-provider/src/test/java/edu/jhu/library/pass/deposit/provider/j10p/MultipleAssemblyDspaceMetsAssemblerIT.java
+++ b/jscholarship-package-provider/src/test/java/edu/jhu/library/pass/deposit/provider/j10p/MultipleAssemblyDspaceMetsAssemblerIT.java
@@ -18,17 +18,15 @@ package edu.jhu.library.pass.deposit.provider.j10p;
 import org.dataconservancy.pass.deposit.DepositTestUtil;
 import org.dataconservancy.pass.deposit.assembler.Assembler;
 import org.dataconservancy.pass.deposit.assembler.PackageStream;
-import org.dataconservancy.pass.deposit.assembler.shared.ExceptionHandlingThreadPoolExecutor;
-import org.dataconservancy.pass.deposit.builder.fs.SharedSubmissionUtil;
+import org.dataconservancy.pass.deposit.builder.fs.FilesystemModelBuilder;
 import org.dataconservancy.pass.deposit.model.DepositSubmission;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import resources.SharedSubmissionUtil;
 
 import javax.xml.parsers.DocumentBuilderFactory;
 import java.io.File;
 import java.net.URI;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.TimeUnit;
 
 import static edu.jhu.library.pass.deposit.provider.j10p.DspaceDepositTestUtil.getMetsXml;
 import static org.dataconservancy.pass.deposit.DepositTestUtil.packageFile;
@@ -47,7 +45,7 @@ public class MultipleAssemblyDspaceMetsAssemblerIT extends BaseDspaceMetsAssembl
 
     @Override
     public void setUp() throws Exception {
-        // override so that super class methods do nothing
+        builder = new FilesystemModelBuilder();
     }
 
     /**

--- a/nihms-package-provider/pom.xml
+++ b/nihms-package-provider/pom.xml
@@ -64,12 +64,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-beans</artifactId>
-            <version>${spring-framework.version}</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.dataconservancy.pass.deposit</groupId>
             <artifactId>deposit-model</artifactId>
             <version>${deposit-services.version}</version>
@@ -88,6 +82,16 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.dataconservancy.pass.deposit</groupId>
             <artifactId>shared-assembler</artifactId>
             <version>${deposit-services.version}</version>
@@ -96,18 +100,17 @@
         </dependency>
 
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-core</artifactId>
+            <groupId>org.dataconservancy.pass.deposit</groupId>
+            <artifactId>shared-resources</artifactId>
+            <version>${deposit-services.version}</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-context</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
+            <groupId>org.dataconservancy.pass.deposit</groupId>
+            <artifactId>fedora-builder</artifactId>
+            <version>${deposit-services.version}</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
@@ -129,46 +132,12 @@
         </dependency>
 
         <dependency>
-            <groupId>io.github.lukehutch</groupId>
-            <artifactId>fast-classpath-scanner</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.xmlunit</groupId>
             <artifactId>xmlunit-core</artifactId>
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-            <groupId>org.dataconservancy.pass.deposit</groupId>
-            <artifactId>fedora-builder</artifactId>
-            <version>${deposit-services.version}</version>
-            <scope>test</scope>
-            <classifier>tests</classifier>
-            <type>test-jar</type>
-        </dependency>
 
-        <dependency>
-            <groupId>org.dataconservancy.pass.deposit</groupId>
-            <artifactId>shared-resources</artifactId>
-            <version>${deposit-services.version}</version>
-            <scope>test</scope>
-            <classifier>tests</classifier>
-            <type>test-jar</type>
-        </dependency>
-
-        <dependency>
-            <groupId>org.dataconservancy.pass.deposit</groupId>
-            <artifactId>fedora-builder</artifactId>
-            <version>${deposit-services.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>com.thoughtworks.xstream</groupId>
-            <artifactId>xstream</artifactId>
-        </dependency>
 
     </dependencies>
 


### PR DESCRIPTION
https://github.com/OA-PASS/deposit-services/pull/222 moved the content of the `shared-resources` module from `src/test` to `src/main`. 

This allows package providers to depend on `shared-resources` as a `<scope>test</scope>` dependency without using a special classifier.  It also allows for the transitive dependencies of `shared-resources` to be included on the test classpath, easing dependency management.

This PR updates the package providers to align with this updated `shared-resources` dependency.