### PR TITLE
Map JournalPublicationType `OPUB` to `EPUB` when serializing NIHMS metadata

### DIFF
--- a/nihms-package-provider/MetadataSerializerTest.xml
+++ b/nihms-package-provider/MetadataSerializerTest.xml
@@ -4,6 +4,8 @@
   <manuscript id="00001" publisher_pdf="yes" show_publisher_pdf="no" href="http://farm.com/Cows" doi="10.1234/smh0000001"/>
   <journal-meta>
     <journal-id journal-id-type="nlm-ta">FJ001</journal-id>
+    <issn pub-type="epub">8765-4321</issn>
+    <issn pub-type="ppub">0000-0000</issn>
     <issn pub-type="epub">1234-5678</issn>
     <journal-title>Dairy Cow Monthly</journal-title>
   </journal-meta>

--- a/nihms-package-provider/src/main/java/org/dataconservancy/pass/deposit/provider/nihms/NihmsMetadataSerializer.java
+++ b/nihms-package-provider/src/main/java/org/dataconservancy/pass/deposit/provider/nihms/NihmsMetadataSerializer.java
@@ -26,6 +26,7 @@ import com.thoughtworks.xstream.io.xml.DomDriver;
 import com.thoughtworks.xstream.io.xml.XmlFriendlyNameCoder;
 import org.dataconservancy.pass.deposit.assembler.shared.SizedStream;
 import org.dataconservancy.pass.deposit.model.DepositMetadata;
+import org.dataconservancy.pass.deposit.model.JournalPublicationType;
 
 import java.io.ByteArrayOutputStream;
 import java.util.List;
@@ -109,7 +110,13 @@ public class NihmsMetadataSerializer implements StreamingSerializer {
 
                 journal.getIssnPubTypes().values().forEach(issnPubType -> {
                     writer.startNode("issn");
-                    writer.addAttribute("pub-type", issnPubType.pubType.name().toLowerCase());
+                    // The JournalPublicationType OPUB should be translated to JournalPublicationType EPUB to stay
+                    // valid with respect to the NIHMS metadata schema
+                    if (issnPubType.pubType == JournalPublicationType.OPUB) {
+                        writer.addAttribute("pub-type", JournalPublicationType.EPUB.name().toLowerCase());
+                    } else {
+                        writer.addAttribute("pub-type", issnPubType.pubType.name().toLowerCase());
+                    }
                     writer.setValue(issnPubType.issn);
                     writer.endNode();
                 });

--- a/nihms-package-provider/src/test/java/org/dataconservancy/pass/deposit/provider/nihms/NihmsAssemblerIT.java
+++ b/nihms-package-provider/src/test/java/org/dataconservancy/pass/deposit/provider/nihms/NihmsAssemblerIT.java
@@ -29,6 +29,7 @@ import org.dataconservancy.pass.deposit.model.DepositFile;
 import org.dataconservancy.pass.deposit.model.DepositFileType;
 import org.dataconservancy.pass.deposit.model.DepositMetadata;
 import org.dataconservancy.pass.deposit.model.DepositMetadata.Person;
+import org.dataconservancy.pass.deposit.model.JournalPublicationType;
 import org.junit.Before;
 import org.junit.Test;
 import org.w3c.dom.Document;
@@ -246,9 +247,16 @@ public class NihmsAssemblerIT extends BaseAssemblerIT {
         assertEquals(issnPubTypes.size(), issns.size());
         assertTrue(issnPubTypes.size() > 0);
 
-        issnPubTypes.values().forEach(issnPubType -> {
-            assertTrue(issns.stream().anyMatch(element -> element.getTextContent().equals(issnPubType.issn) && element.getAttribute("pub-type").equals(issnPubType.pubType.name().toLowerCase())));
+        issns.forEach(issn -> assertTrue(issnPubTypes.containsKey(issn.getTextContent())));
+        issns.forEach(issn -> {
+            DepositMetadata.IssnPubType pubType = issnPubTypes.get(issn.getTextContent());
+            if (pubType.pubType == JournalPublicationType.OPUB) {
+                assertEquals(issn.getAttribute("pub-type"), JournalPublicationType.EPUB.name().toLowerCase());
+            } else {
+                assertEquals(issn.getAttribute("pub-type"), pubType.pubType.name().toLowerCase());
+            }
         });
+
     }
 
     /**

--- a/nihms-package-provider/src/test/java/org/dataconservancy/pass/deposit/provider/nihms/NihmsMetadataSerializerTest.java
+++ b/nihms-package-provider/src/test/java/org/dataconservancy/pass/deposit/provider/nihms/NihmsMetadataSerializerTest.java
@@ -64,7 +64,11 @@ public class NihmsMetadataSerializerTest {
         journal.setJournalTitle("Dairy Cow Monthly");
         journal.setIssnPubTypes(new HashMap<String, DepositMetadata.IssnPubType>() {
             {
-                put("1234-5678", new DepositMetadata.IssnPubType("1234-5678", JournalPublicationType.EPUB));
+                put("8765-4321", new DepositMetadata.IssnPubType("8765-4321", JournalPublicationType.EPUB));
+                // OPUB publication type should be expressed as an EPUB in the resulting metadata per the NIHMS
+                // bulk submission metadata requirements
+                put("1234-5678", new DepositMetadata.IssnPubType("1234-5678", JournalPublicationType.OPUB));
+                put("0000-0000", new DepositMetadata.IssnPubType("0000-0000", JournalPublicationType.PPUB));
             }
         });
 


### PR DESCRIPTION
Update the NihmsMetadataSerializer to emit JournalPublicationType.EPUB when JournalPublicationType.OPUB is seen in the metadata.

The publication type "Online" is introduced into the PASS Submission metadata blob with the advent of the metadata schemas.  But the publication type "Online" will not validate with respect to the NIHMS bulk metadata schema; the NIHMS bulk metadata schema requires "Electronic" as a value instead.  Updates tests.