### PR TITLE
Use a property to represent the Deposit Services Docker image version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,7 @@
         <docker.postgres.version>oapass/postgres:latest</docker.postgres.version>
         <docker.dspace.version>oapass/dspace:latest</docker.dspace.version>
         <docker.ftp.version>oapass/ftpserver:latest</docker.ftp.version>
-        <docker.deposit-services-core.version>oapass/deposit-services-core:1.0.0-3.4-SNAPSHOT</docker.deposit-services-core.version>
+        <docker.deposit-services-core.version>oapass/deposit-services-core:${deposit-services.version}</docker.deposit-services-core.version>
         <docker.assets.version>birkland/assets@sha256:60310d68c7ab910096f471bf6636b35487c52ab6db970fc280959f49eec0f465</docker.assets.version>
 
         <pass.jsonld.context>https://oa-pass.github.io/pass-data-model/src/main/resources/context-3.4.jsonld</pass.jsonld.context>


### PR DESCRIPTION
Use property variable to represent the core Deposit Services Docker image.  This insures that during the release process the release version of the Docker image will be used.