### PR TITLE
Prepare for 0.0.1 release of package providers

### DIFF
--- a/provider-integration/pom.xml
+++ b/provider-integration/pom.xml
@@ -462,14 +462,12 @@
         <dependency>
             <groupId>org.dataconservancy.pass</groupId>
             <artifactId>pass-client-api</artifactId>
-            <version>0.5.3-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.dataconservancy.pass</groupId>
             <artifactId>pass-data-client</artifactId>
-            <version>0.5.3-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Use the deposit-parent BOM to provide the version of the pass-client-api to use. (Version 0.6.0 in this case).