### PR TITLE
Initial gh action workflows from PLAYGROUND

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: pass-docker-services Continuous Integration
+on: [ pull_request, workflow_dispatch ]
+
+concurrency:
+  group: ci-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  print-workflow-description:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "This is a CI build of branch ${{ github.ref }} in repository ${{ github.repository }}"
+      - run: echo "This job was triggered by a ${{ github.event_name }} event and is running on a ${{ runner.os }} server"
+
+  call-workaround:
+    name: Run Parent POM Workaround
+    uses: eclipse-pass/pass-package-providers/.github/workflows/parent-pom-workaround.yml@main
+  
+  call-tests-unit:
+    name: Run Unit Tests
+    uses: eclipse-pass/pass-package-providers/.github/workflows/tests-unit.yml@main
+    needs: call-workaround
+    
+  call-tests-integration:
+    name: Run Integration Tests
+    uses: eclipse-pass/pass-package-providers/.github/workflows/tests-integration.yml@main
+    needs: call-workaround

--- a/.github/workflows/parent-pom-workaround.yml
+++ b/.github/workflows/parent-pom-workaround.yml
@@ -1,0 +1,24 @@
+name: Parent POM Workaround
+on:
+  workflow_call
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Parent POM Workaround: Checkout pass 'main'"
+        uses: actions/checkout@v2
+        with:
+          repository: eclipse-pass/main
+      - name: "Set up JDK 11"
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: "Cache Maven packages"
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: "Parent POM Workaround: Install from pass 'main'"
+        run: mvn install --file pom.xml

--- a/.github/workflows/tests-integration.yml
+++ b/.github/workflows/tests-integration.yml
@@ -1,0 +1,22 @@
+name: Run Unit Tests
+on:
+  workflow_call
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Run Integration Tests
+        run: mvn verify --file pom.xml

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -1,0 +1,22 @@
+name: Run Unit Tests
+on:
+  workflow_call
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Run Unit Tests
+        run: mvn test --file pom.xml


### PR DESCRIPTION
Issues:
- On my local system, tests fail until I manually install `http://maven.dataconservancy.org/public/releases/org/dataconservancy/pass/mets-api/1.3.0/mets-api-1.3.0.jar` into my local repository using: `mvn org.apache.maven.plugins:maven-install-plugin:2.5.2:install-file -Dfile=mets-api-1.3.0.jar`.