### PR TITLE
Java 11 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,30 +12,8 @@ jobs:
       - run: echo "This is a CI build of branch ${{ github.ref }} in repository ${{ github.repository }}"
       - run: echo "This job was triggered by a ${{ github.event_name }} event and is running on a ${{ runner.os }} server"
 
-  pom-workaround:
-    name: "Run Parent POM Workaround"
-    runs-on: ubuntu-latest
-    steps:
-      - name: "Parent POM Workaround: Checkout pass 'main'"
-        uses: actions/checkout@v2
-        with:
-          repository: eclipse-pass/main
-      - name: "Set up JDK 11"
-        uses: actions/setup-java@v1
-        with:
-          java-version: 11
-      - name: "Cache Maven packages"
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
-      - name: "Parent POM Workaround: Install from pass 'main'"
-        run: mvn install --file pom.xml
-
   run-tests:
     name: "Run Unit & Integration Tests"
-    needs: pom-workaround
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout the repository"
@@ -57,4 +35,4 @@ jobs:
           maven-version: 3.8.5
 
       - name: "Run unit & integration tests"
-        run: mvn verify --file pom.xml
+        run: mvn verify -V -ntp --file pom.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,8 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          key: ${{ runner.os }}-mvn-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-mvn
 
       - name: Set up Maven
         uses: stCarolas/setup-maven@v4.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Set up Maven
         uses: stCarolas/setup-maven@v4.3
         with:
-          maven-version: 3.6.3
+          maven-version: 3.8.5
 
       - name: "Run unit & integration tests"
         run: mvn verify --file pom.xml

--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@
 .classpath
 .settings/
 target/
+.vscode/
 
 nihms-native-assembler/MetadataSerializerTest.xml

--- a/bagit-package-provider/pom.xml
+++ b/bagit-package-provider/pom.xml
@@ -98,6 +98,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>log4j-over-slf4j</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.dataconservancy.pass.deposit</groupId>
       <artifactId>shared-assembler</artifactId>
       <version>${deposit-services.version}</version>

--- a/bagit-package-provider/pom.xml
+++ b/bagit-package-provider/pom.xml
@@ -93,9 +93,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.dataconservancy.pass</groupId>
+      <groupId>io.github.joergreichert</groupId>
       <artifactId>mets-api</artifactId>
-      <version>${mets-api.version}</version>
     </dependency>
 
     <dependency>

--- a/jscholarship-package-provider/pom.xml
+++ b/jscholarship-package-provider/pom.xml
@@ -93,6 +93,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>log4j-over-slf4j</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>io.github.joergreichert</groupId>
       <artifactId>mets-api</artifactId>
     </dependency>

--- a/jscholarship-package-provider/pom.xml
+++ b/jscholarship-package-provider/pom.xml
@@ -93,9 +93,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.dataconservancy.pass</groupId>
+      <groupId>io.github.joergreichert</groupId>
       <artifactId>mets-api</artifactId>
-      <version>${mets-api.version}</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
     <xstream.version>1.4.10</xstream.version>
     <commons-codec.version>1.11</commons-codec.version>
     <sword2-client.version>0.9.3</sword2-client.version>
-    <mets-api.version>1.3.0</mets-api.version>
+    <mets-api.version>1.3</mets-api.version>
     <tika.version>1.17</tika.version>
     <pass-client.version>0.6.0</pass-client.version>
     <fast-classpath-scanner.version>3.1.5</fast-classpath-scanner.version>
@@ -454,6 +454,12 @@
         <type>pom</type>
       </dependency>
 
+      <dependency>
+        <groupId>io.github.joergreichert</groupId>
+        <artifactId>mets-api</artifactId>
+        <version>${mets-api.version}</version>
+      </dependency>
+
     </dependencies>
 
   </dependencyManagement>
@@ -472,25 +478,7 @@
     <repository>
       <id>spring-libs-snap</id>
       <name>Spring Snapshots</name>
-      <url>https://repo.spring.io/libs-snapshot</url>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-
-    <repository>
-      <id>dc.public.releases</id>
-      <name>Data Conservancy Release Maven Repository</name>
-      <url>http://maven.dataconservancy.org/public/releases/</url>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-
-    <repository>
-      <id>dc.public.snapshots</id>
-      <name>Data Conservancy Snapshot Maven Repository</name>
-      <url>http://maven.dataconservancy.org/public/snapshots/</url>
+      <url>https://repo.spring.io/snapshot</url>
       <snapshots>
         <enabled>true</enabled>
       </snapshots>

--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@
     <commons-net.version>3.6</commons-net.version>
     <commons-compress.version>1.15</commons-compress.version>
     <commons-io.version>2.6</commons-io.version>
-    <mockito.version>2.12.0</mockito.version>
+    <mockito.version>2.20.1</mockito.version>
     <okhttp.version>3.10.0</okhttp.version>
     <guava.version>23.5-jre</guava.version>
     <args4j.version>2.33</args4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -458,6 +458,12 @@
         <groupId>io.github.joergreichert</groupId>
         <artifactId>mets-api</artifactId>
         <version>${mets-api.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
     </dependencies>


### PR DESCRIPTION
Related https://github.com/eclipse-pass/main/issues/241

* Update CI to use Java 11
* Update `mets-api` dependency
  * Including enforcing log4j transitive dependency
* Update `mockito-core` to support Java 11